### PR TITLE
Optionally disable JSON parsing via configuration param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /lib
+package-lock.json

--- a/readme.markdown
+++ b/readme.markdown
@@ -154,3 +154,16 @@ const { messages } = websocketConnect(
   url => new WebSocket(url)
 )
 ```
+
+## How to disable JSON parsing
+
+If you prefer to handle raw messages, you can disable the default `JSON.stringify` on received messages and `JSON.parse` on sent messages with a falsy fourth parameter as such:
+
+```javascript
+const { messages } = websocketConnect(
+  'ws://127.0.0.1:4201/ws',
+  this.inputStream = new QueueingSubject<any>(),
+  url => new WebSocket(url),
+  false
+)
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,8 @@ const defaultWebsocketFactory = (url: string): IWebSocket => new WebSocket(url)
 export default function connect(
   url: string,
   input: Observable<any>,
-  websocketFactory: WebSocketFactory = defaultWebsocketFactory
+  websocketFactory: WebSocketFactory = defaultWebsocketFactory,
+  jsonParse: boolean = true
 ): Connection {
   const connectionStatus = new BehaviorSubject<number>(0)
 
@@ -44,12 +45,14 @@ export default function connect(
       open = true
       connectionStatus.next(connectionStatus.getValue() + 1)
       inputSubscription = input.subscribe(data => {
-        socket.send(JSON.stringify(data))
+        const sendData = jsonParse ? JSON.stringify(data) : data
+        socket.send(sendData)
       })
     }
 
     socket.onmessage = message => {
-      observer.next(JSON.parse(message.data))
+      const nextData = jsonParse ? JSON.parse(message.data) : message.data
+      observer.next(nextData)
     }
 
     socket.onerror = error => {


### PR DESCRIPTION
As per discussed on #6, this is my simplest proposal to implement the optional JSON parsing of WS messages just passing a falsy fourth parameter to `websocketConnect` method