### PR TITLE
Add explicit any to IWebSocket interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,10 @@ export interface Connection {
 export interface IWebSocket {
   close()
   send(data: string | ArrayBuffer | Blob)
-  onopen?: (OpenEvent) => any
-  onclose?: (CloseEvent) => any
-  onmessage?: (MessageEvent) => any
-  onerror?: (ErrorEvent) => any
+  onopen?: (OpenEvent: any) => any
+  onclose?: (CloseEvent: any) => any
+  onmessage?: (MessageEvent: any) => any
+  onerror?: (ErrorEvent: any) => any
 }
 
 export type WebSocketFactory = (url: string, protocols?: string | string[]) => IWebSocket


### PR DESCRIPTION
Allows noImplicityAny rule in tsconfig.json of projects, since this is annoying :)

```
Error at node_modules/rxjs-websockets/lib/index.d.ts:9:15: Parameter 'OpenEvent' implicitly has an 'any' type.
Error at node_modules/rxjs-websockets/lib/index.d.ts:10:16: Parameter 'CloseEvent' implicitly has an 'any' type.
Error at node_modules/rxjs-websockets/lib/index.d.ts:11:18: Parameter 'MessageEvent' implicitly has an 'any' type.
Error at node_modules/rxjs-websockets/lib/index.d.ts:12:16: Parameter 'ErrorEvent' implicitly has an 'any' type.
```

