### PR TITLE
fix: type error when using queueing-subject as input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { Observable } from 'rxjs/Observable'
-import { Subscription } from 'rxjs/Subscription'
+import { Observable, Subscribable } from 'rxjs/Observable'
+import { AnonymousSubscription } from 'rxjs/Subscription'
 import { BehaviorSubject } from 'rxjs/BehaviorSubject'
 
 export interface Connection {
@@ -22,7 +22,7 @@ const defaultWebsocketFactory = (url: string, protocol?: string): IWebSocket => 
 
 export default function connect(
   url: string,
-  input: Observable<string>,
+  input: Subscribable<string>,
   protocols?: string | string[],
   websocketFactory: WebSocketFactory = defaultWebsocketFactory,
 ): Connection {
@@ -30,7 +30,7 @@ export default function connect(
 
   const messages = new Observable<string>(observer => {
     const socket = websocketFactory(url, protocols)
-    let inputSubscription: Subscription
+    let inputSubscription: AnonymousSubscription
 
     let open = false
     const closed = () => {


### PR DESCRIPTION
Using something quite similar to the example in the [readme](https://github.com/ohjames/rxjs-websockets#angular-4-example), I am getting this type error:

```
Argument of type 'QueueingSubject<string>' is not assignable to parameter of type 'Observable<string>'.
  Property 'buffer' is missing in type 'QueueingSubject<string>'.
```

```js
  protected connect(url: string) {
    if (this.messages$) {
      return;
    }

    this.inputStream = new QueueingSubject<string>();

    const { messages, connectionStatus } = websocketConnect(
      url,
      this.inputStream,
    );

    this.messages$ = messages
      .share()
      .retryWhen(errors => errors.delay(1000));

    this.connectionStatus$ = connectionStatus;
  }
```

Relevant package versions:
```
"queueing-subject": "^0.1.1",
"rxjs": "^5.4.2",
"rxjs-websockets": "^4.0.0",
"typescript": "^2.5.3",
```