### PR TITLE
fix observer completion by completing it only if unsubscribed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,8 @@ export default function connect(
     let inputSubscription: Subscription
 
     let open = false
+    let forcedClose = false
+
     const closed = () => {
       if (! open)
         return
@@ -58,13 +60,14 @@ export default function connect(
 
     socket.onclose = (event: CloseEvent) => {
       closed()
-      if (event.wasClean)
+      if (forcedClose)
         observer.complete()
       else
         observer.error(new Error(event.reason))
     }
 
     return () => {
+      forcedClose = true
       if (inputSubscription)
         inputSubscription.unsubscribe()
 


### PR DESCRIPTION
The current implementation `complete`s the observable upon receiving a WebSocket `close` event with the `wasClean` property set to true.
The `wasClean` property is true if the WebSocket close handshake completes gracefully, even if it closed due to a code other than `1000` (Normal Closure).

This can cause issues with servers that gracefully shutdown upon restarting by closing all open WebSocket connections and waiting for the close handshake to complete.
In this case, the observable would incorrectly complete, thereby causing any attached retries (for e.g., via `retryWhen`) to not be attempted.

Moreover, if the `messages` observable is unsubscribed from (resulting in `socket.close()` being called) and the close handshake doesn't complete gracefully, the WebSocket `close` event will be triggered with `wasClean` set to false. This will result in an error (`observer.error(error)`) and cause any attached retries to be attempted. In this case, the observable, IMHO, should `complete` normally and not throw an error.

Most (non-reactive) WebSocket libraries handle retries by retrying upon receiving a `close` event only if the connection wasn't explicitly instructed to be closed via some API method, without relying on `event.wasClean`. This ensures that closed connections are retried if the API user didn't intend to close the connection, and connections closed via some API method are not retried even if the close handshake didn't complete (`event.wasClean === false` ).

