### PR TITLE
Fixing reconnect when server terminates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export default function connect(
 
     socket.onopen = () => {
       open = true
+      forcedClose = false
       connectionStatus.next(connectionStatus.getValue() + 1)
       inputSubscription = input.subscribe(data => {
         socket.send(data)
@@ -60,7 +61,7 @@ export default function connect(
 
     socket.onclose = (event: CloseEvent) => {
       closed()
-      if (forcedClose)
+      if (event.code === 1000 && forcedClose)
         observer.complete()
       else
         observer.error(new Error(event.reason))


### PR DESCRIPTION
This pull request fixes issues that make retryWhen() unusable for reconnect. The fundamental issue seems to be that that the onclose() callback always results in an unsubscribe, which ultimately sets forcedClose to true and triggers the onclose callback Ultimately this means the observable always completes, and the error never propagates to retryWhen. Because of this,forcedClose doesn't actually mean the client initiated a close via unsubscribing the socket; it simply  means the observable errored or completed at least once before the onclose() callback actually ran.

The solution that seems to work is to also check the code on the CloseEvent. In the case where a user initiates a close, the unsubscribe() callback should run *first*. This means forcedClose will be true before the close event, which should have a code of 1000 (Normal close). This should be the only case where the observable completes. Conversely, if the server initiates a close, forcedClose *should* be false, and the code could be 1000 or 1006 (normally 1006 in my case, but I assume that is server dependent). In either case, the websocket will continue trying to reconnect until the server comes back up. 

Ultimately, it seems like the only case where the observable should complete is when the client closes the socket. All other cases should allow for retry. Please let me know if I'm misunderstanding how this should work, or if other changes are necessary.