### PR TITLE
Removed -S

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -19,9 +19,9 @@ An rxjs websocket library with a simple and flexible implementation. Supports th
 Install the dependency:
 
 ```bash
-npm install -S rxjs-websockets
+npm install rxjs-websockets
 # the following dependency is recommended for most users
-npm install -S queueing-subject
+npm install queueing-subject
 ```
 
 ## Simple usage


### PR DESCRIPTION
https://github.com/ohjames/rxjs-websockets/issues/46

removed -S which is on longer needed or documented,

>         npm install saves any specified packages into dependencies by default.
>         Additionally, you can control where and how they get saved with some
>         additional flags: