### PR TITLE
fix: set default protocol to empty array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,14 @@ export interface IWebSocket {
 
 export type WebSocketFactory = (url: string, protocols?: string | string[]) => IWebSocket
 
-const defaultWebsocketFactory = (url: string, protocol?: string): IWebSocket => new WebSocket(url, protocol)
+const defaultProtocols = [];
+
+const defaultWebsocketFactory: WebSocketFactory = (url: string, protocols: string | string[] = defaultProtocols): IWebSocket => new WebSocket(url, protocols)
 
 export default function connect(
   url: string,
   input: Observable<string>,
-  protocols?: string | string[],
+  protocols: string | string[] = defaultProtocols,
   websocketFactory: WebSocketFactory = defaultWebsocketFactory,
 ): Connection {
   const connectionStatus = new BehaviorSubject<number>(0)


### PR DESCRIPTION
This prevents an issue on firefox and edge where the browsers will send the value 'undefined' for the header `Sec-WebSocket-Protocol`. This is different to the behavior of WebKit browsers which omit the header if the value is undefined. Using just `WebSocket(url)` can also fix this problem. This undefined header can then cause further issues if the server sends back a response with an empty `Sec-WebSocket-Protocol` header, which will cause the browser to reject the WebSocket connection as closed (ReadyState 3).

Not strictly a problem with `rxjs-websockets` by any means, but it'd probably help to prevent against other people running into this problem of subtle browser differences.