### PR TITLE
Added ArrayBuffer and Blob as data types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { Observable, Subscription, BehaviorSubject } from 'rxjs'
 
-export interface Connection {
+export interface Connection<T> {
   connectionStatus: Observable<number>,
-  messages: Observable<string>,
+  messages: Observable<T>,
 }
 
 export interface IWebSocket {
@@ -25,7 +25,7 @@ export default function connect<T extends string | ArrayBuffer | Blob = string |
   input: Observable<T>,
   protocols: string | string[] = defaultProtocols,
   websocketFactory: WebSocketFactory = defaultWebsocketFactory,
-): Connection {
+): Connection<T> {
   const connectionStatus = new BehaviorSubject<number>(0)
 
   const messages = new Observable<T>(observer => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Observable, Subscription, BehaviorSubject } from 'rxjs'
 
-export interface Connection<T> {
+export interface Connection<T extends string | ArrayBuffer | Blob = string | ArrayBuffer | Blob> {
   connectionStatus: Observable<number>,
   messages: Observable<T>,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,15 +20,15 @@ const defaultProtocols = [];
 
 const defaultWebsocketFactory: WebSocketFactory = (url: string, protocols: string | string[] = defaultProtocols): IWebSocket => new WebSocket(url, protocols)
 
-export default function connect(
+export default function connect<T extends string | ArrayBuffer | Blob = string | ArrayBuffer | Blob>(
   url: string,
-  input: Observable<string>,
+  input: Observable<T>,
   protocols: string | string[] = defaultProtocols,
   websocketFactory: WebSocketFactory = defaultWebsocketFactory,
 ): Connection {
   const connectionStatus = new BehaviorSubject<number>(0)
 
-  const messages = new Observable<string>(observer => {
+  const messages = new Observable<T>(observer => {
     const socket = websocketFactory(url, protocols)
     let inputSubscription: Subscription
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Observable, Subscription, BehaviorSubject } from 'rxjs'
 
-export interface Connection<T extends string | ArrayBuffer | Blob = string | ArrayBuffer | Blob> {
+export interface Connection<T extends (string | ArrayBuffer | Blob) = (string | ArrayBuffer | Blob)> {
   connectionStatus: Observable<number>,
   messages: Observable<T>,
 }
@@ -20,7 +20,7 @@ const defaultProtocols = [];
 
 const defaultWebsocketFactory: WebSocketFactory = (url: string, protocols: string | string[] = defaultProtocols): IWebSocket => new WebSocket(url, protocols)
 
-export default function connect<T extends string | ArrayBuffer | Blob = string | ArrayBuffer | Blob>(
+export default function connect<T extends (string | ArrayBuffer | Blob) = (string | ArrayBuffer | Blob)>(
   url: string,
   input: Observable<T>,
   protocols: string | string[] = defaultProtocols,


### PR DESCRIPTION
Added multiple variants of incoming and outcoming data, instead of just `string` and gave a way to narrow to down via generic. It's not super accurate as #49 tried to achieve, but it's something one can work with.

It's a breaking change unfortunately, but I can't think of any sane way to mitigate it (defaulting generic to `string` doens't look good to me). Let me know if you're comfortable with such changes, so I can update README with the new info.

Fixes #28 